### PR TITLE
chore: add missing changelog entries for Admin v7.59.x to v7.64.x

### DIFF
--- a/changelog/tagoio-admin/2025-02-04-v7-58-0.md
+++ b/changelog/tagoio-admin/2025-02-04-v7-58-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.58.0"
-description: "Adding support for the two server regions (United States East and Europe West) on Admin , TagoRUN , and Embed"
+description: "Adding support for the two server regions (United States East and Europe West) on Admin, TagoRUN, and Embed"
 slug: "/tagoio-admin/v7-58-0"
 product: "tagoio-admin"
 version: "v7.58.0"

--- a/changelog/tagoio-admin/2025-02-12-v7-58-1.md
+++ b/changelog/tagoio-admin/2025-02-12-v7-58-1.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.58.1"
+description: "Add persistence for groups on the sidebar dashboard list"
+slug: "/tagoio-admin/v7-58-1"
+product: "tagoio-admin"
+version: "v7.58.1"
+---
+
+## Highlights
+
+- Adding persistence to open dashboard groups in the dashboard list when navigating
+- Fixing timezone precedence on the Dynamic Table widget
+- Fixing incorrect color for email inside the TagoRUN account menu
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-02-12-v7-58-1.md
+++ b/changelog/tagoio-admin/2025-02-12-v7-58-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.58.1"
-description: "Add persistence for groups on the sidebar dashboard list"
+description: "Adding persistence for groups on the sidebar dashboard list"
 slug: "/tagoio-admin/v7-58-1"
 product: "tagoio-admin"
 version: "v7.58.1"

--- a/changelog/tagoio-admin/2025-02-19-v7-58-2.md
+++ b/changelog/tagoio-admin/2025-02-19-v7-58-2.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.58.2"
-description: "Add customization options for Map widget buttons"
+description: "Adding customization options for Map widget buttons"
 slug: "/tagoio-admin/v7-58-2"
 product: "tagoio-admin"
 version: "v7.58.2"

--- a/changelog/tagoio-admin/2025-02-19-v7-58-2.md
+++ b/changelog/tagoio-admin/2025-02-19-v7-58-2.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.58.2"
+description: "Add customization options for Map widget buttons"
+slug: "/tagoio-admin/v7-58-2"
+product: "tagoio-admin"
+version: "v7.58.2"
+---
+
+## Highlights
+
+- Adding customization options for Map widget buttons
+- Adding filters by Geofence events on Map widget
+- Fixing integration with Google Analytics not working with Anonymous users
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-02-26-v7-58-3.md
+++ b/changelog/tagoio-admin/2025-02-26-v7-58-3.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.58.3"
-description: "Add option to list by Geofences on the Map widget"
+description: "Adding option to list by Geofences on the Map widget"
 slug: "/tagoio-admin/v7-58-3"
 product: "tagoio-admin"
 version: "v7.58.3"

--- a/changelog/tagoio-admin/2025-02-26-v7-58-3.md
+++ b/changelog/tagoio-admin/2025-02-26-v7-58-3.md
@@ -1,0 +1,22 @@
+---
+title: "TagoIO Admin v7.58.3"
+description: "Add option to list by Geofences on the Map widget"
+slug: "/tagoio-admin/v7-58-3"
+product: "tagoio-admin"
+version: "v7.58.3"
+---
+
+## Highlights
+
+- Adding option to list by Geofences on the Map widget
+- Fixing deleting tabs on dashboard not deleting the tab's widgets
+- Fixing password reset getting stuck and improving the message
+- Fixing edge case when loading dashboards with empty resolved data on Embed
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-03-10-v7-58-4.md
+++ b/changelog/tagoio-admin/2025-03-10-v7-58-4.md
@@ -1,0 +1,20 @@
+---
+title: "TagoIO Admin v7.58.4"
+description: "Adding region select page, Embed fixes"
+slug: "/tagoio-admin/v7-58-4"
+product: "tagoio-admin"
+version: "v7.58.4"
+---
+
+## Highlights
+
+- Adding region select page
+- Fixing saving edited rows on the Entity Table widget in Embed dashboards
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-03-10-v7-58-4.md
+++ b/changelog/tagoio-admin/2025-03-10-v7-58-4.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.58.4"
-description: "Adding region select page, Embed fixes"
+description: "Adding region select page, fixing save on edited rows for Entity Table"
 slug: "/tagoio-admin/v7-58-4"
 product: "tagoio-admin"
 version: "v7.58.4"

--- a/changelog/tagoio-admin/2025-03-11-v7-59-0.md
+++ b/changelog/tagoio-admin/2025-03-11-v7-59-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.59.0"
-description: "Add Entity data fields on Input Form and Dynamic Table"
+description: "Adding Entity data fields on Input Form and Dynamic Table"
 slug: "/tagoio-admin/v7-59-0"
 product: "tagoio-admin"
 version: "v7.59.0"

--- a/changelog/tagoio-admin/2025-03-11-v7-59-0.md
+++ b/changelog/tagoio-admin/2025-03-11-v7-59-0.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.59.0"
+description: "Add Entity data fields on Input Form and Dynamic Table"
+slug: "/tagoio-admin/v7-59-0"
+product: "tagoio-admin"
+version: "v7.59.0"
+---
+
+## Highlights
+
+- Adding Entity data fields on Input Form widget
+- Adding Entity data fields on Dynamic Table widget
+- Fixing zero being displayed empty cell on Entity Table widget
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-03-12-v7-59-1.md
+++ b/changelog/tagoio-admin/2025-03-12-v7-59-1.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.59.1"
+description: "Fix enforced 2FA with unset phone number"
+slug: "/tagoio-admin/v7-59-1"
+product: "tagoio-admin"
+version: "v7.59.1"
+---
+
+## Highlights
+
+- Fixing enforced 2FA not submitting phone number when unset in account
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-03-12-v7-59-1.md
+++ b/changelog/tagoio-admin/2025-03-12-v7-59-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.59.1"
-description: "Fix enforced 2FA with unset phone number"
+description: "Fixing enforced 2FA with unset phone number"
 slug: "/tagoio-admin/v7-59-1"
 product: "tagoio-admin"
 version: "v7.59.1"

--- a/changelog/tagoio-admin/2025-03-31-v7-60-0.md
+++ b/changelog/tagoio-admin/2025-03-31-v7-60-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.60.0"
-description: "Add realtime for Entity widgets"
+description: "Adding realtime for Entity widgets"
 slug: "/tagoio-admin/v7-60-0"
 product: "tagoio-admin"
 version: "v7.60.0"

--- a/changelog/tagoio-admin/2025-03-31-v7-60-0.md
+++ b/changelog/tagoio-admin/2025-03-31-v7-60-0.md
@@ -1,0 +1,22 @@
+---
+title: "TagoIO Admin v7.60.0"
+description: "Add realtime for Entity widgets"
+slug: "/tagoio-admin/v7-60-0"
+product: "tagoio-admin"
+version: "v7.60.0"
+---
+
+## Highlights
+
+- Adding realtime (SSE) for Entity data on widgets
+- Adding Entity data source on Input Form widget
+- Fixing logic to check changed Blueprint associations on Custom Widget
+- Fixing file uploads API on TagoIO SDK
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-04-01-v7-60-1.md
+++ b/changelog/tagoio-admin/2025-04-01-v7-60-1.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.60.1"
+description: "Fix Analysis scope in header buttons"
+slug: "/tagoio-admin/v7-60-1"
+product: "tagoio-admin"
+version: "v7.60.1"
+---
+
+## Highlights
+
+- Fixing Analysis scope in widget header buttons
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-04-01-v7-60-1.md
+++ b/changelog/tagoio-admin/2025-04-01-v7-60-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.60.1"
-description: "Fix Analysis scope in header buttons"
+description: "Fixing Analysis scope in header buttons"
 slug: "/tagoio-admin/v7-60-1"
 product: "tagoio-admin"
 version: "v7.60.1"

--- a/changelog/tagoio-admin/2025-04-07-v7-61-0.md
+++ b/changelog/tagoio-admin/2025-04-07-v7-61-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.0"
-description: "Add support for Dashboard templates with mock data"
+description: "Adding support for Dashboard templates with mock data"
 slug: "/tagoio-admin/v7-61-0"
 product: "tagoio-admin"
 version: "v7.61.0"

--- a/changelog/tagoio-admin/2025-04-07-v7-61-0.md
+++ b/changelog/tagoio-admin/2025-04-07-v7-61-0.md
@@ -1,0 +1,20 @@
+---
+title: "TagoIO Admin v7.61.0"
+description: "Add support for Dashboard templates with mock data"
+slug: "/tagoio-admin/v7-61-0"
+product: "tagoio-admin"
+version: "v7.61.0"
+---
+
+## Highlights
+
+- Adding support to generate and install Dashboard templates with mock data
+- Adding support for public Dashboard templates in Dashboard wizard
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-04-09-v7-61-1.md
+++ b/changelog/tagoio-admin/2025-04-09-v7-61-1.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.61.1"
+description: "Fix edge case when loading public templates"
+slug: "/tagoio-admin/v7-61-1"
+product: "tagoio-admin"
+version: "v7.61.1"
+---
+
+## Highlights
+
+- Fixing failing requests when loading public Dashboard templates
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-04-09-v7-61-1.md
+++ b/changelog/tagoio-admin/2025-04-09-v7-61-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.1"
-description: "Fix edge case when loading public templates"
+description: "Fixing edge case when loading public templates"
 slug: "/tagoio-admin/v7-61-1"
 product: "tagoio-admin"
 version: "v7.61.1"

--- a/changelog/tagoio-admin/2025-04-15-v7-61-2.md
+++ b/changelog/tagoio-admin/2025-04-15-v7-61-2.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.61.2"
+description: "Fix formulas with Analysis and Validation fields on Input Form"
+slug: "/tagoio-admin/v7-61-2"
+product: "tagoio-admin"
+version: "v7.61.2"
+---
+
+## Highlights
+
+- Fixing formula not being applied when submitting to Analysis on the Input Form widget
+- Fixing precedence for metadata and type colors in Validation fields on the Input Form widget
+- Improving inconsistent visual styles in the Dashboard wizard templates section
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-04-15-v7-61-2.md
+++ b/changelog/tagoio-admin/2025-04-15-v7-61-2.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.2"
-description: "Fix formulas with Analysis and Validation fields on Input Form"
+description: "Fixing formulas with Analysis and Validation fields on Input Form"
 slug: "/tagoio-admin/v7-61-2"
 product: "tagoio-admin"
 version: "v7.61.2"

--- a/changelog/tagoio-admin/2025-05-14-v7-61-4.md
+++ b/changelog/tagoio-admin/2025-05-14-v7-61-4.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.61.4"
+description: "Add logout route on TagoRUN, fix sign in after expired session"
+slug: "/tagoio-admin/v7-61-4"
+product: "tagoio-admin"
+version: "v7.61.4"
+---
+
+## Highlights
+
+- Adding support for the logout route with and without SSO enabled on TagoRUN
+- Fixing logging in after token expires looping to Sign In page
+- Fixing inconsistent behavior with file uploads on Input Form widget
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-05-14-v7-61-4.md
+++ b/changelog/tagoio-admin/2025-05-14-v7-61-4.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.4"
-description: "Add logout route on TagoRUN, fix sign in after expired session"
+description: "Adding logout route on TagoRUN, fixing sign in loop after session expires"
 slug: "/tagoio-admin/v7-61-4"
 product: "tagoio-admin"
 version: "v7.61.4"

--- a/changelog/tagoio-admin/2025-05-26-v7-61-5.md
+++ b/changelog/tagoio-admin/2025-05-26-v7-61-5.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.61.5"
+description: "Fix ghost elements when searching Blueprint Devices"
+slug: "/tagoio-admin/v7-61-5"
+product: "tagoio-admin"
+version: "v7.61.5"
+---
+
+## Highlights
+
+- Fixing ghost elements when searching in Blueprint Device selector with similar names
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-05-26-v7-61-5.md
+++ b/changelog/tagoio-admin/2025-05-26-v7-61-5.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.5"
-description: "Fix ghost elements when searching Blueprint Devices"
+description: "Fixing ghost elements when searching Blueprint Devices"
 slug: "/tagoio-admin/v7-61-5"
 product: "tagoio-admin"
 version: "v7.61.5"

--- a/changelog/tagoio-admin/2025-06-04-v7-61-6.md
+++ b/changelog/tagoio-admin/2025-06-04-v7-61-6.md
@@ -1,0 +1,20 @@
+---
+title: "TagoIO Admin v7.61.6"
+description: "Fix empty values in Formulas on Device/User List"
+slug: "/tagoio-admin/v7-61-6"
+product: "tagoio-admin"
+version: "v7.61.6"
+---
+
+## Highlights
+
+- Fixing empty values in Formulas on the Device List and User List widgets
+- Fixing vertical scrolling and pagination on Entity List widget
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-06-04-v7-61-6.md
+++ b/changelog/tagoio-admin/2025-06-04-v7-61-6.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.61.6"
-description: "Fix empty values in Formulas on Device/User List"
+description: "Fixing empty values in Formulas on Device/User List"
 slug: "/tagoio-admin/v7-61-6"
 product: "tagoio-admin"
 version: "v7.61.6"

--- a/changelog/tagoio-admin/2025-06-23-v7-62-0.md
+++ b/changelog/tagoio-admin/2025-06-23-v7-62-0.md
@@ -8,7 +8,7 @@ version: "v7.62.0"
 
 ## Highlights
 
-- Update TagoIO SDK to the v12 major version
+- Updating TagoIO SDK to the v12 major version
 
 ## Breaking Changes
 

--- a/changelog/tagoio-admin/2025-06-23-v7-62-0.md
+++ b/changelog/tagoio-admin/2025-06-23-v7-62-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.62.0"
-description: "Update TagoIO SDK to v12 major"
+description: "Updating TagoIO SDK to v12 major"
 slug: "/tagoio-admin/v7-62-0"
 product: "tagoio-admin"
 version: "v7.62.0"

--- a/changelog/tagoio-admin/2025-06-23-v7-62-0.md
+++ b/changelog/tagoio-admin/2025-06-23-v7-62-0.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.62.0"
+description: "Update TagoIO SDK to v12 major"
+slug: "/tagoio-admin/v7-62-0"
+product: "tagoio-admin"
+version: "v7.62.0"
+---
+
+## Highlights
+
+- Update TagoIO SDK to the v12 major version
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-06-24-v7-62-1.md
+++ b/changelog/tagoio-admin/2025-06-24-v7-62-1.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.62.1"
+description: "Fix minor issues from TagoIO SDK v12 update"
+slug: "/tagoio-admin/v7-62-1"
+product: "tagoio-admin"
+version: "v7.62.1"
+---
+
+## Highlights
+
+- Fixing minor issues from the update to TagoIO SDK v12
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-06-24-v7-62-1.md
+++ b/changelog/tagoio-admin/2025-06-24-v7-62-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.62.1"
-description: "Fix minor issues from TagoIO SDK v12 update"
+description: "Fixing minor issues from TagoIO SDK v12 update"
 slug: "/tagoio-admin/v7-62-1"
 product: "tagoio-admin"
 version: "v7.62.1"

--- a/changelog/tagoio-admin/2025-06-24-v7-62-2.md
+++ b/changelog/tagoio-admin/2025-06-24-v7-62-2.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.62.2"
+description: "Update type definitions for Payload Parser"
+slug: "/tagoio-admin/v7-62-2"
+product: "tagoio-admin"
+version: "v7.62.2"
+---
+
+## Highlights
+
+- Updating type definitions for the Payload Parser editor
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-06-24-v7-62-2.md
+++ b/changelog/tagoio-admin/2025-06-24-v7-62-2.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.62.2"
-description: "Update type definitions for Payload Parser"
+description: "Updating type definitions for Payload Parser"
 slug: "/tagoio-admin/v7-62-2"
 product: "tagoio-admin"
 version: "v7.62.2"

--- a/changelog/tagoio-admin/2025-06-27-v7-62-3.md
+++ b/changelog/tagoio-admin/2025-06-27-v7-62-3.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.62.3"
-description: "Fix inconsistent message ordering on Custom Widget"
+description: "Fixing inconsistent message ordering on Custom Widget"
 slug: "/tagoio-admin/v7-62-3"
 product: "tagoio-admin"
 version: "v7.62.3"

--- a/changelog/tagoio-admin/2025-06-27-v7-62-3.md
+++ b/changelog/tagoio-admin/2025-06-27-v7-62-3.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.62.3"
+description: "Fix inconsistent message ordering on Custom Widget"
+slug: "/tagoio-admin/v7-62-3"
+product: "tagoio-admin"
+version: "v7.62.3"
+---
+
+## Highlights
+
+- Fixing inconsistent ordering in the Custom Widget messaging system
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-07-01-v7-62-4.md
+++ b/changelog/tagoio-admin/2025-07-01-v7-62-4.md
@@ -1,0 +1,23 @@
+---
+title: "TagoIO Admin v7.62.4"
+description: "Fix validation with session_id parameter"
+slug: "/tagoio-admin/v7-62-4"
+product: "tagoio-admin"
+version: "v7.62.4"
+---
+
+## Highlights
+
+- Fixing validation with `session_id` parameter closing all modal forms
+- Fixing page not found not being shown when API call for TagoRUN information errors
+- Fixing handling of newline characters in Validation fields on Input Form widget
+- Fixing defaults on the internal API helpers
+- Changing Ask Documentation to send messages with context
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-07-01-v7-62-4.md
+++ b/changelog/tagoio-admin/2025-07-01-v7-62-4.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.62.4"
-description: "Fix validation with session_id parameter"
+description: "Fixing validation with session_id parameter"
 slug: "/tagoio-admin/v7-62-4"
 product: "tagoio-admin"
 version: "v7.62.4"

--- a/changelog/tagoio-admin/2025-08-12-v7-63-0.md
+++ b/changelog/tagoio-admin/2025-08-12-v7-63-0.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.63.0"
-description: "Add customization for Map widget tiles"
+description: "Adding customization for Map widget tiles"
 slug: "/tagoio-admin/v7-63-0"
 product: "tagoio-admin"
 version: "v7.63.0"

--- a/changelog/tagoio-admin/2025-08-12-v7-63-0.md
+++ b/changelog/tagoio-admin/2025-08-12-v7-63-0.md
@@ -1,0 +1,22 @@
+---
+title: "TagoIO Admin v7.63.0"
+description: "Add customization for Map widget tiles"
+slug: "/tagoio-admin/v7-63-0"
+product: "tagoio-admin"
+version: "v7.63.0"
+---
+
+## Highlights
+
+- Adding customization for map tiles on Map and Input Form widget
+- Adding missing Dictionary key for SSO login button on TagoRUN web
+- Fixing edge case with Entity widget when using invalid index
+- Fixing unnecessary Agreements requests failing with Anonymous user access
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-08-12-v7-63-1.md
+++ b/changelog/tagoio-admin/2025-08-12-v7-63-1.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.63.1"
+description: "Fix zoom offset when using mock data in Map"
+slug: "/tagoio-admin/v7-63-1"
+product: "tagoio-admin"
+version: "v7.63.1"
+---
+
+## Highlights
+
+- Fixing zoom offset when using mock data in Map widget
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-08-12-v7-63-1.md
+++ b/changelog/tagoio-admin/2025-08-12-v7-63-1.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.63.1"
-description: "Fix zoom offset when using mock data in Map"
+description: "Fixing zoom offset when using mock data in Map"
 slug: "/tagoio-admin/v7-63-1"
 product: "tagoio-admin"
 version: "v7.63.1"

--- a/changelog/tagoio-admin/2025-08-14-v7-63-2.md
+++ b/changelog/tagoio-admin/2025-08-14-v7-63-2.md
@@ -1,6 +1,6 @@
 ---
 title: "TagoIO Admin v7.63.2"
-description: "Add redirect system for TagoDeploy migrations"
+description: "Adding redirect system for TagoDeploy migrations"
 slug: "/tagoio-admin/v7-63-2"
 product: "tagoio-admin"
 version: "v7.63.2"

--- a/changelog/tagoio-admin/2025-08-14-v7-63-2.md
+++ b/changelog/tagoio-admin/2025-08-14-v7-63-2.md
@@ -1,0 +1,19 @@
+---
+title: "TagoIO Admin v7.63.2"
+description: "Add redirect system for TagoDeploy migrations"
+slug: "/tagoio-admin/v7-63-2"
+product: "tagoio-admin"
+version: "v7.63.2"
+---
+
+## Highlights
+
+- Adding redirect system to assist in migration from multi-tenant to single-tenant TagoRUN URLs
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-08-20-v7-64-0.md
+++ b/changelog/tagoio-admin/2025-08-20-v7-64-0.md
@@ -1,0 +1,24 @@
+---
+title: "TagoIO Admin v7.64.0"
+description: "Adding support for new Analysis runtimes and snippets"
+slug: "/tagoio-admin/v7-64-0"
+product: "tagoio-admin"
+version: "v7.64.0"
+---
+
+## Highlights
+
+- Adding support to the new Analysis runtimes
+- Adding support to the new Analysis snippets
+- Adding option to change the runtime of an Analysis
+- Improving Analysis logs to be displayed in groups (similar to Live Inspector)
+- Fixing tile styles on custom MapBox defaulting to satellite
+- Updating TagoIO SDK to v12.2.1
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-09-09-v7-64-3.md
+++ b/changelog/tagoio-admin/2025-09-09-v7-64-3.md
@@ -1,0 +1,21 @@
+---
+title: "TagoIO Admin v7.64.3"
+description: "Adding external link support on TagoRUN sidebar buttons"
+slug: "/tagoio-admin/v7-64-3"
+product: "tagoio-admin"
+version: "v7.64.3"
+---
+
+## Highlights
+
+- Adding sidebar button type to open external links in browser
+- Changing parser snippets to load from public repository
+- Fixing data format for coordinates when exporting data from Devices
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required

--- a/changelog/tagoio-admin/2025-09-30-v7-64-5.md
+++ b/changelog/tagoio-admin/2025-09-30-v7-64-5.md
@@ -1,0 +1,22 @@
+---
+title: "TagoIO Admin v7.64.5"
+description: "Fixing issues on Embed, fixed units on widgets, and Billing units"
+slug: "/tagoio-admin/v7-64-5"
+product: "tagoio-admin"
+version: "v7.64.5"
+---
+
+## Highlights
+
+- Fixing visualization preferences not being applied on the Input Form widget on Embed
+- Fixing chart legend not being displayed when changing preset interval on Embed
+- Fixing fixed unit not being editable on widgets when formula is disabled
+- Fixing size unit amounts on the Billing page
+
+## Breaking Changes
+
+- None
+
+## Upgrade Notes
+
+- No special actions required


### PR DESCRIPTION
Add changelog entries up to the Admin v7.64.5 versions released today.