### PR TITLE
Add deprecation notice to Legacy MQTT page

### DIFF
--- a/docs/tagoio/integrations/networks/mqtt/mqtt.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt.md
@@ -6,6 +6,18 @@ keywords: [tagoio, iot, mqtt, broker, protocol]
 sidebar_position: 1
 ---
 
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** This integration will be removed in a future release.
+New accounts created after April 15, 2026 no longer have access to this feature.
+
+If you are currently using Legacy MQTT, please plan your migration to the
+[new MQTT connector](/docs/tagoio/integrations/networks/mqtt-connector/) or
+the [HTTP API](/docs/tagoio/api/).
+
+Existing devices and actions using Legacy MQTT will continue to function during
+the deprecation period, but no new features or bug fixes will be provided.
+:::
+
 ## Important notice
 
 :::warning

--- a/docs/tagoio/integrations/networks/mqtt/mqtt.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt.md
@@ -11,8 +11,8 @@ sidebar_position: 1
 New accounts created after April 15, 2026 no longer have access to this feature.
 
 If you are currently using Legacy MQTT, please plan your migration to the
-[new MQTT connector](/docs/tagoio/integrations/networks/mqtt-connector/) or
-the [HTTP API](/docs/tagoio/api/).
+[MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio) or
+the [HTTP API](/docs/tagoio/api/api_overview).
 
 Existing devices and actions using Legacy MQTT will continue to function during
 the deprecation period, but no new features or bug fixes will be provided.


### PR DESCRIPTION
## Summary

- Adds a `:::warning[Deprecation Notice]` admonition at the top of the MQTT overview page
- Informs readers that Legacy MQTT is deprecated and will be removed in a future release
- Directs users to the new MQTT connector and HTTP API as alternatives
- Notes that accounts created after April 15, 2026 no longer have access

## Test plan

- [ ] Docusaurus renders the warning admonition correctly at the top of the page
- [ ] Migration links to the MQTT connector and HTTP API resolve properly
- [ ] Existing page content below the notice is unaffected