### PR TITLE
Add deprecation notice to Legacy MQTT page

### DIFF
--- a/cdk/lambda/index.js
+++ b/cdk/lambda/index.js
@@ -444,7 +444,7 @@ exports.handler = async (event) => {
     "/portal/en/kb/articles/configuration-parameters-for-devices":
       "/docs/tagoio/devices/configuration-parameters-for-devices",
     "/portal/en/kb/articles/connecting-your-mqtt-broker-to-tagoio":
-      "/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio",
+      "/docs/tagoio/integrations/networks/third-party-mqtt-broker",
     "/portal/en/kb/articles/control-tower": "/docs/tagoio/addons/control-tower",
     "/portal/en/kb/articles/custom-domain-configuration":
       "/docs/tagoio/addons/custom-domain/custom-domain-configuration",
@@ -524,7 +524,7 @@ exports.handler = async (event) => {
     "/portal/en/kb/articles/tagoio-mcp-ai-powered-iot-data-integration":
       "/docs/tagoio/getting-started/tagoio-mcp-ai-powered-iot-data-integration",
     "/portal/en/kb/articles/tagoio-mqtt-relay":
-      "/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio",
+      "/docs/tagoio/integrations/networks/third-party-mqtt-broker",
     "/portal/en/kb/articles/tags": "/docs/tagoio/getting-started/tags-system",
     "/portal/en/kb/articles/ticket-severity-options":
       "/docs/tagoio/support/ticket-severity-options",

--- a/cdk/lambda/index.js
+++ b/cdk/lambda/index.js
@@ -444,7 +444,7 @@ exports.handler = async (event) => {
     "/portal/en/kb/articles/configuration-parameters-for-devices":
       "/docs/tagoio/devices/configuration-parameters-for-devices",
     "/portal/en/kb/articles/connecting-your-mqtt-broker-to-tagoio":
-      "/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio",
+      "/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio",
     "/portal/en/kb/articles/control-tower": "/docs/tagoio/addons/control-tower",
     "/portal/en/kb/articles/custom-domain-configuration":
       "/docs/tagoio/addons/custom-domain/custom-domain-configuration",
@@ -524,7 +524,7 @@ exports.handler = async (event) => {
     "/portal/en/kb/articles/tagoio-mcp-ai-powered-iot-data-integration":
       "/docs/tagoio/getting-started/tagoio-mcp-ai-powered-iot-data-integration",
     "/portal/en/kb/articles/tagoio-mqtt-relay":
-      "/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio",
+      "/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio",
     "/portal/en/kb/articles/tags": "/docs/tagoio/getting-started/tags-system",
     "/portal/en/kb/articles/ticket-severity-options":
       "/docs/tagoio/support/ticket-severity-options",

--- a/docs/tagoio/actions/defining-actions.md
+++ b/docs/tagoio/actions/defining-actions.md
@@ -192,7 +192,7 @@ TagoIO [MQTT Broker](/docs/tagoio/integrations/networks/mqtt/mqtt.md) is availab
 exclusively for **Starter** and **Scale** accounts in the **US database
 region**. Free accounts and European database region accounts may utilize
 third‑party MQTT services with TagoIO via the
-[MQTT Relay](/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio.md)
+[MQTT Relay](/docs/tagoio/integrations/networks/third-party-mqtt-broker.md)
 feature.
 
 ## Post data to HTTP End-Point

--- a/docs/tagoio/actions/defining-actions.md
+++ b/docs/tagoio/actions/defining-actions.md
@@ -192,7 +192,7 @@ TagoIO [MQTT Broker](/docs/tagoio/integrations/networks/mqtt/mqtt.md) is availab
 exclusively for **Starter** and **Scale** accounts in the **US database
 region**. Free accounts and European database region accounts may utilize
 third‑party MQTT services with TagoIO via the
-[MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md)
+[MQTT Relay](/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio.md)
 feature.
 
 ## Post data to HTTP End-Point

--- a/docs/tagoio/actions/trigger-by-mqtt-topic.md
+++ b/docs/tagoio/actions/trigger-by-mqtt-topic.md
@@ -14,9 +14,10 @@ the MQTT infrastructure used by TagoIO, see
 [MQTT](/docs/tagoio/integrations/networks/mqtt/mqtt.md).
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
-have access. The TagoIO MQTT Broker was available exclusively for Starter and
-Scale accounts in the US database region.
+**Legacy MQTT is deprecated.** The TagoIO MQTT Broker was available exclusively
+for Starter and Scale accounts in the US database region that upgraded before
+April 15, 2026. Accounts created or upgraded after that date do not have access
+to this feature.
 
 Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
 all account types and regions (US and EU).

--- a/docs/tagoio/actions/trigger-by-mqtt-topic.md
+++ b/docs/tagoio/actions/trigger-by-mqtt-topic.md
@@ -13,14 +13,16 @@ messages are published to the topics they are subscribed to. To learn more about
 the MQTT infrastructure used by TagoIO, see
 [MQTT](/docs/tagoio/integrations/networks/mqtt/mqtt.md).
 
-:::info
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
+have access. The TagoIO MQTT Broker was available exclusively for Starter and
+Scale accounts in the US database region.
 
-The TagoIO MQTT Broker is available exclusively for Starter and Scale accounts
-in the US database region. Free accounts and accounts hosted in the European
-database region may use third-party MQTT services with TagoIO via the
-[MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md)
-feature.
+Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
+all account types and regions (US and EU).
 
+Existing devices and actions will continue to function during the deprecation
+period, but no new features or bug fixes will be provided.
 :::
 
 ## Trigger categories

--- a/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio.md
+++ b/docs/tagoio/integrations/networks/connecting-your-mqtt-broker-to-tagoio.md
@@ -1,10 +1,16 @@
 ---
-title: "Connecting your MQTT Broker to TagoIO"
-description: "This article explains TagoIO's MQTT Relay, a command-line tool that bridges an external MQTT broker and the TagoIO platform, and points to the repository and a demonstration video for setup and usage."
+title: "MQTT Relay"
+description: "TagoIO MQTT Relay bridges an external MQTT broker and the TagoIO platform using a fast, open-source command-line tool."
 tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, broker, relay]
-sidebar_position: 2
+sidebar_position: 10
 ---
+
+:::tip
+For direct MQTT connectivity without an external broker, use
+[TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports all account types
+and regions (US and EU).
+:::
 
 TagoIO supports MQTT connections through the MQTT Relay command-line tool. The
 relay acts as a bridge between your MQTT Broker and the TagoIO platform,

--- a/docs/tagoio/integrations/networks/mqtt/_category_.json
+++ b/docs/tagoio/integrations/networks/mqtt/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "MQTT",
+  "label": "MQTT (Legacy)",
   "collapsed": true
 }

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-process-data-publish-it-and-subscribe-to-a-topic.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-process-data-publish-it-and-subscribe-to-a-topic.md
@@ -6,9 +6,10 @@ keywords: [tagoio, iot, mqtt, publish, subscribe]
 ---
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
-have access. The TagoIO MQTT Broker was available exclusively for Starter and
-Scale accounts in the US database region.
+**Legacy MQTT is deprecated.** The TagoIO MQTT Broker was available exclusively
+for Starter and Scale accounts in the US database region that upgraded before
+April 15, 2026. Accounts created or upgraded after that date do not have access
+to this feature.
 
 Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
 all account types and regions (US and EU).

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-process-data-publish-it-and-subscribe-to-a-topic.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-process-data-publish-it-and-subscribe-to-a-topic.md
@@ -5,12 +5,16 @@ tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, publish, subscribe]
 ---
 
-:::warning
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
+have access. The TagoIO MQTT Broker was available exclusively for Starter and
+Scale accounts in the US database region.
 
-TagoIO MQTT Broker is available exclusively for Starter and Scale accounts in the US database region. European (EU) database region accounts cannot access this service due to new security requirements, but they may use third‑party MQTT services with TagoIO via the [MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md) feature. Free accounts can access MQTT functionality through the MQTT Relay as well.
+Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
+all account types and regions (US and EU).
 
-For EU accounts, a public MQTT broker without SLA guarantees is planned for the future. The main purpose of that broker will be proof‑of‑concept testing.
-
+Existing devices and actions will continue to function during the deprecation
+period, but no new features or bug fixes will be provided.
 :::
 
 In this tutorial, you will learn how to process data, publish to a topic, and subscribe to it. The tutorial uses the **MQTTX** client throughout.

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-publishing-and-subscribing.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-publishing-and-subscribing.md
@@ -5,19 +5,16 @@ tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, publishing, subscribing, analysis]
 ---
 
-:::warning
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
+have access. The TagoIO MQTT Broker was available exclusively for Starter and
+Scale accounts in the US database region.
 
-TagoIO MQTT Broker is available exclusively for Starter and Scale accounts in
-the US database region. European (EU) database region accounts cannot access
-this service due to new security requirements, but they may use third‑party MQTT
-services with TagoIO via the
-[MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md)
-feature. Free accounts can access MQTT functionality through the MQTT Relay as
-well.
+Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
+all account types and regions (US and EU).
 
-For EU accounts, a public MQTT broker without SLA guarantees is planned for the
-future. The main purpose of that broker will be proof‑of‑concept testing.
-
+Existing devices and actions will continue to function during the deprecation
+period, but no new features or bug fixes will be provided.
 :::
 
 You can publish to your MQTT topics by coding a script that runs from an

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-publishing-and-subscribing.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-publishing-and-subscribing.md
@@ -6,9 +6,10 @@ keywords: [tagoio, iot, mqtt, publishing, subscribing, analysis]
 ---
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
-have access. The TagoIO MQTT Broker was available exclusively for Starter and
-Scale accounts in the US database region.
+**Legacy MQTT is deprecated.** The TagoIO MQTT Broker was available exclusively
+for Starter and Scale accounts in the US database region that upgraded before
+April 15, 2026. Accounts created or upgraded after that date do not have access
+to this feature.
 
 Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
 all account types and regions (US and EU).

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-retain-on-tagoio-broker.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-retain-on-tagoio-broker.md
@@ -6,9 +6,10 @@ keywords: [tagoio, iot, mqtt, retain, broker]
 ---
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
-have access. The TagoIO MQTT Broker was available exclusively for Starter and
-Scale accounts in the US database region.
+**Legacy MQTT is deprecated.** The TagoIO MQTT Broker was available exclusively
+for Starter and Scale accounts in the US database region that upgraded before
+April 15, 2026. Accounts created or upgraded after that date do not have access
+to this feature.
 
 Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
 all account types and regions (US and EU).

--- a/docs/tagoio/integrations/networks/mqtt/mqtt-retain-on-tagoio-broker.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt-retain-on-tagoio-broker.md
@@ -5,10 +5,16 @@ tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, retain, broker]
 ---
 
-:::warning
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
+have access. The TagoIO MQTT Broker was available exclusively for Starter and
+Scale accounts in the US database region.
 
-TagoIO MQTT Broker is available exclusively for Starter and Scale accounts in the US database region. Free accounts and accounts in the European database region may use third‑party MQTT services with TagoIO via the [MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md) feature.
+Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
+all account types and regions (US and EU).
 
+Existing devices and actions will continue to function during the deprecation
+period, but no new features or bug fixes will be provided.
 :::
 
 TagoIO's MQTT broker does not natively support the standard MQTT **retain** feature. However, you can implement an equivalent workaround by using TagoIO Analysis and Actions to store the last message published to a topic and resend it when a new client subscribes.

--- a/docs/tagoio/integrations/networks/mqtt/mqtt.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt.md
@@ -6,6 +6,17 @@ keywords: [tagoio, iot, mqtt, broker, protocol]
 sidebar_position: 1
 ---
 
+:::warning[Deprecation Notice]
+**Legacy MQTT is deprecated.** This integration will be removed in a future release.
+New accounts created after April 15, 2026 no longer have access to this feature.
+
+If you are currently using Legacy MQTT, please migrate to
+[TagoTIP MQTT](/docs/tagotip/transports/mqtt).
+
+Existing devices and actions using Legacy MQTT will continue to function during
+the deprecation period, but no new features or bug fixes will be provided.
+:::
+
 ## Important notice
 
 :::warning

--- a/docs/tagoio/integrations/networks/mqtt/mqtt.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt.md
@@ -7,9 +7,10 @@ sidebar_position: 1
 ---
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
-have access. The TagoIO MQTT Broker was available exclusively for Starter and
-Scale accounts in the US database region.
+**Legacy MQTT is deprecated.** The TagoIO MQTT Broker was available exclusively
+for Starter and Scale accounts in the US database region that upgraded before
+April 15, 2026. Accounts created or upgraded after that date do not have access
+to this feature.
 
 Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
 all account types and regions (US and EU).
@@ -38,7 +39,7 @@ full‑featured MQTT implementation, it focuses mainly on ingesting sensor data
 into our data buckets, so some standard features such as the native **Retain**
 flag are not supported. A workaround that achieves similar functionality can be
 found in the article
-[MQTT Retain on TagoIO Broker](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md).
+[MQTT Retain on TagoIO Broker](/docs/tagoio/integrations/networks/mqtt/mqtt-retain-on-tagoio-broker.md).
 
 For example, a temperature sensor might publish a new value to the topic
 `temperature` each time it receives an update. Devices that need to react to

--- a/docs/tagoio/integrations/networks/mqtt/mqtt.md
+++ b/docs/tagoio/integrations/networks/mqtt/mqtt.md
@@ -1,37 +1,21 @@
 ---
-title: "MQTT Overview"
-description: "A brief introduction to TagoIO's MQTT support, including availability restrictions, an overview of the MQTT protocol, and a diagram showing data flow between devices and the TagoIO MQTT broker."
+title: "MQTT Overview (Legacy)"
+description: "Legacy MQTT integration for TagoIO. This feature is deprecated -- please use TagoTiP MQTT instead."
 tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, broker, protocol]
 sidebar_position: 1
 ---
 
 :::warning[Deprecation Notice]
-**Legacy MQTT is deprecated.** This integration will be removed in a future release.
-New accounts created after April 15, 2026 no longer have access to this feature.
+**Legacy MQTT is deprecated.** Accounts created after April 15, 2026 no longer
+have access. The TagoIO MQTT Broker was available exclusively for Starter and
+Scale accounts in the US database region.
 
-If you are currently using Legacy MQTT, please migrate to
-[TagoTIP MQTT](/docs/tagotip/transports/mqtt).
+Please migrate to [TagoTiP MQTT](/docs/tagotip/transports/mqtt), which supports
+all account types and regions (US and EU).
 
-Existing devices and actions using Legacy MQTT will continue to function during
-the deprecation period, but no new features or bug fixes will be provided.
-:::
-
-## Important notice
-
-:::warning
-
-TagoIO MQTT Broker is available exclusively for Starter and Scale accounts in
-the US database region. European (EU) database region accounts cannot access
-this service due to new security requirements, but they may use third‑party MQTT
-services with TagoIO via the
-[MQTT Relay](/docs/tagoio/integrations/networks/mqtt/connecting-your-mqtt-broker-to-tagoio.md)
-feature. Free accounts can access MQTT functionality through the MQTT Relay as
-well.
-
-For EU accounts, a public MQTT broker without SLA guarantees is planned for the
-future. The main purpose of that broker will be proof‑of‑concept testing.
-
+Existing devices and actions will continue to function during the deprecation
+period, but no new features or bug fixes will be provided.
 :::
 
 ## Overview

--- a/docs/tagoio/integrations/networks/third-party-mqtt-broker.md
+++ b/docs/tagoio/integrations/networks/third-party-mqtt-broker.md
@@ -1,9 +1,9 @@
 ---
-title: "MQTT Relay"
+title: "Bridging a Third-Party MQTT Broker"
+sidebar_label: "Third-Party MQTT Broker"
 description: "TagoIO MQTT Relay bridges an external MQTT broker and the TagoIO platform using a fast, open-source command-line tool."
 tags: ["tagoio"]
 keywords: [tagoio, iot, mqtt, broker, relay]
-sidebar_position: 10
 ---
 
 :::tip


### PR DESCRIPTION
## Summary

- Adds a deprecation warning admonition at the top of the MQTT overview page
- Directs users to migrate to [TagoTIP MQTT](/docs/tagotip/transports/mqtt)
- Notes that accounts created after April 15, 2026 no longer have access

## Test plan

- [ ] Docusaurus renders the warning admonition correctly at the top of the page
- [ ] TagoTIP MQTT link resolves properly
- [ ] Existing page content below the notice is unaffected